### PR TITLE
Tiled-mode for project_images.py and resumable training

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,5 @@ FROM tensorflow/tensorflow:1.15.0-gpu-py3
 RUN pip install scipy==1.3.3
 RUN pip install requests==2.22.0
 RUN pip install Pillow==6.2.1
+
+COPY . /src

--- a/pretrained_networks.py
+++ b/pretrained_networks.py
@@ -9,6 +9,7 @@
 import pickle
 import dnnlib
 import dnnlib.tflib as tflib
+import os
 
 #----------------------------------------------------------------------------
 # StyleGAN2 Google Drive root: https://drive.google.com/open?id=1QHc-yF5C3DChRwSdZKcx1w6K8JvSxQi7
@@ -67,7 +68,7 @@ def load_networks(path_or_gdrive_path):
         return _cached_networks[path_or_url]
 
     if dnnlib.util.is_url(path_or_url):
-        stream = dnnlib.util.open_url(path_or_url, cache_dir='.stylegan2-cache')
+        stream = dnnlib.util.open_url(path_or_url, cache_dir=os.environ.get('STYLEGAN2_CACHE', '.stylegan2-cache'))
     else:
         stream = open(path_or_url, 'rb')
 

--- a/project_images.py
+++ b/project_images.py
@@ -87,6 +87,10 @@ def main():
     parser.add_argument('--initial-learning-rate', type=float, default=0.1, help='Initial learning rate')
     parser.add_argument('--initial-noise-factor', type=float, default=0.05, help='Initial noise factor')
     parser.add_argument('--verbose', type=bool, default=False, help='Verbose output')
+    tiled_parser = parser.add_mutually_exclusive_group(required=False)
+    tiled_parser.add_argument('--tiled', dest='tiled', action='store_true', help='Tiled dlatents (default)')
+    tiled_parser.add_argument('--no-tiled', dest='tiled', action='store_false', help='Non-tiled dlatents')
+    parser.set_defaults(tiled=True)
     parser.add_argument('--video', type=bool, default=False, help='Render video of the optimization process')
     parser.add_argument('--video-mode', type=int, default=1, help='Video mode: 1 for optimization only, 2 for source + optimization')
     parser.add_argument('--video-size', type=int, default=1024, help='Video size (height in px)')
@@ -102,7 +106,8 @@ def main():
         num_steps             = args.num_steps,
         initial_learning_rate = args.initial_learning_rate,
         initial_noise_factor  = args.initial_noise_factor,
-        verbose               = args.verbose
+        verbose               = args.verbose,
+        tiled                 = args.tiled
     )
     proj.set_network(Gs)
 

--- a/projector.py
+++ b/projector.py
@@ -19,7 +19,8 @@ class Projector:
         num_steps                       = 1000,
         initial_learning_rate           = 0.1,
         initial_noise_factor            = 0.05,
-        verbose                         = False
+        verbose                         = False,
+        tiled                           = True
     ):
 
         self.vgg16_pkl                  = vgg16_pkl
@@ -32,6 +33,7 @@ class Projector:
         self.noise_ramp_length          = 0.75
         self.regularize_noise_weight    = 1e5
         self.verbose                    = verbose
+        self.tiled                      = tiled
         self.clone_net                  = True
 
         self._Gs                    = None
@@ -71,8 +73,11 @@ class Projector:
         # Find dlatent stats.
         self._info('Finding W midpoint and stddev using %d samples...' % self.dlatent_avg_samples)
         latent_samples = np.random.RandomState(123).randn(self.dlatent_avg_samples, *self._Gs.input_shapes[0][1:])
-        dlatent_samples = self._Gs.components.mapping.run(latent_samples, None) # [N, 18, 512]
-        self._dlatent_avg = np.mean(dlatent_samples, axis=0, keepdims=True) # [1, 18, 512]
+        if self.tiled:
+            dlatent_samples = self._Gs.components.mapping.run(latent_samples, None)[:, :1, :] # [N, 1, 512]
+        else:
+            dlatent_samples = self._Gs.components.mapping.run(latent_samples, None) # [N, 18, 512]
+        self._dlatent_avg = np.mean(dlatent_samples, axis=0, keepdims=True) # [1, 1 or 18, 512]
         self._dlatent_std = (np.sum((dlatent_samples - self._dlatent_avg) ** 2) / self.dlatent_avg_samples) ** 0.5
         self._info('std = %g' % self._dlatent_std)
 
@@ -100,7 +105,10 @@ class Projector:
         self._dlatents_var = tf.Variable(tf.zeros([self._minibatch_size] + list(self._dlatent_avg.shape[1:])), name='dlatents_var')
         self._noise_in = tf.placeholder(tf.float32, [], name='noise_in')
         dlatents_noise = tf.random.normal(shape=self._dlatents_var.shape) * self._noise_in
-        self._dlatents_expr = self._dlatents_var + dlatents_noise
+        if self.tiled:
+            self._dlatents_expr = tf.tile(self._dlatents_var + dlatents_noise, [1, self._Gs.components.synthesis.input_shape[1], 1])
+        else:
+            self._dlatents_expr = self._dlatents_var + dlatents_noise
         self._images_expr = self._Gs.components.synthesis.get_output_for(self._dlatents_expr, randomize_noise=False)
 
         # Downsample image to 256x256 if it's larger than that. VGG was built for 224x224 images.

--- a/run_training.py
+++ b/run_training.py
@@ -33,7 +33,7 @@ _valid_configs = [
 
 #----------------------------------------------------------------------------
 
-def run(dataset, data_dir, result_dir, config_id, num_gpus, total_kimg, gamma, mirror_augment, metrics, resume_kimg, resume_pkl):
+def run(dataset, data_dir, result_dir, config_id, num_gpus, total_kimg, gamma, mirror_augment, metrics, resume_kimg, resume_pkl, g_lrate_base, d_lrate_base):
     train     = EasyDict(run_func_name='training.training_loop.training_loop') # Options for training loop.
     G         = EasyDict(func_name='training.networks_stylegan2.G_main')       # Options for generator network.
     D         = EasyDict(func_name='training.networks_stylegan2.D_stylegan2')  # Options for discriminator network.
@@ -51,7 +51,14 @@ def run(dataset, data_dir, result_dir, config_id, num_gpus, total_kimg, gamma, m
     train.mirror_augment = mirror_augment
     train.image_snapshot_ticks = 10
     train.network_snapshot_ticks = 10
-    sched.G_lrate_base = sched.D_lrate_base = 0.002
+    if g_lrate_base is None:
+        sched.G_lrate_base = 0.002
+    else:
+        sched.G_lrate_base = g_lrate_base
+    if d_lrate_base is None:
+        sched.D_lrate_base = 0.002
+    else:
+        sched.D_lrate_base = d_lrate_base
     sched.minibatch_size_base = 32
     sched.minibatch_gpu_base = 4
     D_loss.gamma = 10
@@ -85,7 +92,14 @@ def run(dataset, data_dir, result_dir, config_id, num_gpus, total_kimg, gamma, m
     # Configs A-D: Enable progressive growing and switch to networks that support it.
     if config_id in ['config-a', 'config-b', 'config-c', 'config-d']:
         sched.lod_initial_resolution = 8
-        sched.G_lrate_base = sched.D_lrate_base = 0.001
+        if g_lrate_base is None:
+            sched.G_lrate_base = 0.001
+        else:
+            sched.G_lrate_base = g_lrate_base
+        if d_lrate_base is None:
+            sched.D_lrate_base = 0.001
+        else:
+            sched.D_lrate_base = d_lrate_base
         sched.G_lrate_dict = sched.D_lrate_dict = {128: 0.0015, 256: 0.002, 512: 0.003, 1024: 0.003}
         sched.minibatch_size_base = 32 # (default)
         sched.minibatch_size_dict = {8: 256, 16: 128, 32: 64, 64: 32}
@@ -172,6 +186,8 @@ def main():
     parser.add_argument('--metrics', help='Comma-separated list of metrics or "none" (default: %(default)s)', default='fid50k', type=_parse_comma_sep)
     parser.add_argument('--resume-kimg', help='Assumed training progress at the beginning. Affects reporting and training schedule.', default=0, type=int)
     parser.add_argument('--resume-pkl', help='Network pickle to resume training from. Train from scratch if none provided.', default=None, type=str)
+    parser.add_argument('--g-lrate-base', help='', default=None, type=float)
+    parser.add_argument('--d-lrate-base', help='', default=None, type=float)
 
     args = parser.parse_args()
 

--- a/run_training.py
+++ b/run_training.py
@@ -33,7 +33,7 @@ _valid_configs = [
 
 #----------------------------------------------------------------------------
 
-def run(dataset, data_dir, result_dir, config_id, num_gpus, total_kimg, gamma, mirror_augment, metrics):
+def run(dataset, data_dir, result_dir, config_id, num_gpus, total_kimg, gamma, mirror_augment, metrics, resume_kimg):
     train     = EasyDict(run_func_name='training.training_loop.training_loop') # Options for training loop.
     G         = EasyDict(func_name='training.networks_stylegan2.G_main')       # Options for generator network.
     D         = EasyDict(func_name='training.networks_stylegan2.D_stylegan2')  # Options for discriminator network.
@@ -115,6 +115,7 @@ def run(dataset, data_dir, result_dir, config_id, num_gpus, total_kimg, gamma, m
     kwargs = EasyDict(train)
     kwargs.update(G_args=G, D_args=D, G_opt_args=G_opt, D_opt_args=D_opt, G_loss_args=G_loss, D_loss_args=D_loss)
     kwargs.update(dataset_args=dataset_args, sched_args=sched, grid_args=grid, metric_arg_list=metrics, tf_config=tf_config)
+    kwargs.update(resume_kimg=resume_kimg)
     kwargs.submit_config = copy.deepcopy(sc)
     kwargs.submit_config.run_dir_root = result_dir
     kwargs.submit_config.run_desc = desc
@@ -169,6 +170,7 @@ def main():
     parser.add_argument('--gamma', help='R1 regularization weight (default is config dependent)', default=None, type=float)
     parser.add_argument('--mirror-augment', help='Mirror augment (default: %(default)s)', default=False, metavar='BOOL', type=_str_to_bool)
     parser.add_argument('--metrics', help='Comma-separated list of metrics or "none" (default: %(default)s)', default='fid50k', type=_parse_comma_sep)
+    parser.add_argument('--resume-kimg', help='Assumed training progress at the beginning. Affects reporting and training schedule.', default=0, type=int)
 
     args = parser.parse_args()
 

--- a/run_training.py
+++ b/run_training.py
@@ -49,7 +49,8 @@ def run(dataset, data_dir, result_dir, config_id, num_gpus, total_kimg, gamma, m
     train.data_dir = data_dir
     train.total_kimg = total_kimg
     train.mirror_augment = mirror_augment
-    train.image_snapshot_ticks = train.network_snapshot_ticks = 10
+    train.image_snapshot_ticks = 10
+    train.network_snapshot_ticks = 10
     sched.G_lrate_base = sched.D_lrate_base = 0.002
     sched.minibatch_size_base = 32
     sched.minibatch_gpu_base = 4

--- a/run_training.py
+++ b/run_training.py
@@ -33,7 +33,7 @@ _valid_configs = [
 
 #----------------------------------------------------------------------------
 
-def run(dataset, data_dir, result_dir, config_id, num_gpus, total_kimg, gamma, mirror_augment, metrics, resume_kimg):
+def run(dataset, data_dir, result_dir, config_id, num_gpus, total_kimg, gamma, mirror_augment, metrics, resume_kimg, resume_pkl):
     train     = EasyDict(run_func_name='training.training_loop.training_loop') # Options for training loop.
     G         = EasyDict(func_name='training.networks_stylegan2.G_main')       # Options for generator network.
     D         = EasyDict(func_name='training.networks_stylegan2.D_stylegan2')  # Options for discriminator network.
@@ -115,7 +115,7 @@ def run(dataset, data_dir, result_dir, config_id, num_gpus, total_kimg, gamma, m
     kwargs = EasyDict(train)
     kwargs.update(G_args=G, D_args=D, G_opt_args=G_opt, D_opt_args=D_opt, G_loss_args=G_loss, D_loss_args=D_loss)
     kwargs.update(dataset_args=dataset_args, sched_args=sched, grid_args=grid, metric_arg_list=metrics, tf_config=tf_config)
-    kwargs.update(resume_kimg=resume_kimg)
+    kwargs.update(resume_kimg=resume_kimg, resume_pkl=resume_pkl)
     kwargs.submit_config = copy.deepcopy(sc)
     kwargs.submit_config.run_dir_root = result_dir
     kwargs.submit_config.run_desc = desc
@@ -171,6 +171,7 @@ def main():
     parser.add_argument('--mirror-augment', help='Mirror augment (default: %(default)s)', default=False, metavar='BOOL', type=_str_to_bool)
     parser.add_argument('--metrics', help='Comma-separated list of metrics or "none" (default: %(default)s)', default='fid50k', type=_parse_comma_sep)
     parser.add_argument('--resume-kimg', help='Assumed training progress at the beginning. Affects reporting and training schedule.', default=0, type=int)
+    parser.add_argument('--resume-pkl', help='Network pickle to resume training from. Train from scratch if none provided.', default=None, type=str)
 
     args = parser.parse_args()
 

--- a/training/training_loop.py
+++ b/training/training_loop.py
@@ -131,8 +131,8 @@ def training_loop(
     network_snapshot_ticks  = 50,       # How often to save network snapshots? None = only save 'networks-final.pkl'.
     save_tf_graph           = False,    # Include full TensorFlow computation graph in the tfevents file?
     save_weight_histograms  = False,    # Include weight histograms in the tfevents file?
-    resume_pkl              = None,     # Network pickle to resume training from, None = train from scratch.
-    resume_kimg             = 0.0,      # Assumed training progress at the beginning. Affects reporting and training schedule.
+    resume_pkl              = '/src/stylegan2-ffhq-config-f.pkl',     # Network pickle to resume training from, None = train from scratch.
+    resume_kimg             = 0,      # Assumed training progress at the beginning. Affects reporting and training schedule.
     resume_time             = 0.0,      # Assumed wallclock time at the beginning. Affects reporting.
     resume_with_new_nets    = False):   # Construct new networks according to G_args and D_args before resuming training?
 

--- a/training/training_loop.py
+++ b/training/training_loop.py
@@ -265,6 +265,8 @@ def training_loop(
         G.setup_weight_histograms(); D.setup_weight_histograms()
     metrics = metric_base.MetricGroup(metric_arg_list)
 
+    print('Training schedule configuration is: {}'.format(sched_args))
+
     print('Training for %d kimg...\n' % total_kimg)
     dnnlib.RunContext.get().update('', cur_epoch=resume_kimg, max_epoch=total_kimg)
     maintenance_time = dnnlib.RunContext.get().get_last_update_interval()

--- a/training/training_loop.py
+++ b/training/training_loop.py
@@ -11,6 +11,9 @@ import tensorflow as tf
 import dnnlib
 import dnnlib.tflib as tflib
 from dnnlib.tflib.autosummary import autosummary
+import os
+import glob
+import re
 
 from training import dataset
 from training import misc
@@ -150,10 +153,17 @@ def training_loop(
             D = tflib.Network('D', num_channels=training_set.shape[0], resolution=training_set.shape[1], label_size=training_set.label_size, **D_args)
             Gs = G.clone('Gs')
         if resume_pkl is not None:
+            result_network_pickles = sorted(glob.glob(os.path.join(dnnlib.submit_config.run_dir_root, '0*', 'network-*.pkl')))
+            if len(result_network_pickles) > 0:
+                resume_pkl = result_network_pickles[-1]
+                RE_KIMG = re.compile('network-snapshot-(\d+).pkl')
+                resume_kimg = int(RE_KIMG.match(os.path.basename(resume_pkl)).group(1))
             print('Loading networks from "%s"...' % resume_pkl)
             rG, rD, rGs = misc.load_pkl(resume_pkl)
             if resume_with_new_nets: G.copy_vars_from(rG); D.copy_vars_from(rD); Gs.copy_vars_from(rGs)
             else: G = rG; D = rD; Gs = rGs
+
+    print('Starting from %skimg...' % resume_kimg)
 
     # Print layers and generate initial image snapshot.
     G.print_layers(); D.print_layers()

--- a/training/training_loop.py
+++ b/training/training_loop.py
@@ -131,7 +131,7 @@ def training_loop(
     network_snapshot_ticks  = 50,       # How often to save network snapshots? None = only save 'networks-final.pkl'.
     save_tf_graph           = False,    # Include full TensorFlow computation graph in the tfevents file?
     save_weight_histograms  = False,    # Include weight histograms in the tfevents file?
-    resume_pkl              = '/src/stylegan2-ffhq-config-f.pkl',     # Network pickle to resume training from, None = train from scratch.
+    resume_pkl              = None,     # Network pickle to resume training from, None = train from scratch.
     resume_kimg             = 0,      # Assumed training progress at the beginning. Affects reporting and training schedule.
     resume_time             = 0.0,      # Assumed wallclock time at the beginning. Affects reporting.
     resume_with_new_nets    = False):   # Construct new networks according to G_args and D_args before resuming training?


### PR DESCRIPTION
This PR contains two improvements:
- new command-line argument for `project_images.py`: `--no-tiled` which allows to switch to factory-default projection into `1x512` dlatents-space (useful for evaluation of "semantic" quality of the model);
- a tweak in training loop to resume from the latest network-snapshot if one is found in the `--result-dir`