### PR TITLE
Fix for incompatible layer name in Collab

### DIFF
--- a/encoder/generator_model.py
+++ b/encoder/generator_model.py
@@ -32,7 +32,7 @@ class Generator:
         self.dlatent_variable = next(v for v in tf.global_variables() if 'learnable_dlatents' in v.name)
         self.set_dlatents(self.initial_dlatents)
 
-        self.generator_output = self.graph.get_tensor_by_name('G_synthesis_1/_Run/concat:0')
+        self.generator_output = self.graph.get_tensor_by_name('G_synthesis_1/_Run/concat/concat:0')
         self.generated_image = tflib.convert_images_to_uint8(self.generator_output, nchw_to_nhwc=True, uint8_cast=False)
         self.generated_image_uint8 = tf.saturate_cast(self.generated_image, tf.uint8)
 


### PR DESCRIPTION
This change fixes this bug issue https://github.com/rolux/stylegan2encoder/issues/12

No need the ` tensorflow-gpu` in Collab